### PR TITLE
fix: support non-standard Node.js installations by allowing users to configure the path of the Node.js binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,6 @@ This [Raycast](https://www.raycast.com/) extension allows you to manage your Log
 
 To use this extension, as well as downloading the extension from the Raycast Store, you must also set up [Node.js](https://nodejs.org/en/) and [`npm`](https://www.npmjs.com/), and then install the `litra` npm package globally by running `npm install -g litra`. You must be running at least v4.4.0 of the package.
 
-When you run the extension for the first time, you'll be prompted to provide the directory where the `litra` package's CLI is installed. You can get this by running `dirname $(which litra-on)` from a terminal.
+When you run the extension for the first time, you'll be prompted to configure the "CLI directory" setting, pointing to the directory where the `litra` package's executables are installed. You can get this by running `dirname $(which litra-on)` in a shell.
+
+Depending on how Node.js is installed, you may encounter a `env: node: No such file or directory` error when trying to use the extension. If you do, you should try setting the optional "Node.js binary path" setting. You can get the correct value by running `which node` in a shell.

--- a/package.json
+++ b/package.json
@@ -39,6 +39,13 @@
       "required": true,
       "title": "CLI directory",
       "description": "The path to the directory where the executable files from the `litra` npm package are installed. Install the CLI with `npm install -g litra`, then run `dirname $(which litra-on)`."
+    },
+    {
+      "name": "nodeBinaryPath",
+      "type": "textfield",
+      "required": false,
+      "title": "Node.js binary path",
+      "description": "The path to the Node.js binary. If not specified, the `node` binary in your `PATH` will be used. You should only specify this if you get an error like `env: node: No such file or directory` when trying to use the extension. You can get the correct path by running `which node` in your shell."
     }
   ],
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
       "type": "textfield",
       "required": true,
       "title": "CLI directory",
-      "description": "The path to the directory where the executable files from the `litra` npm package are installed. Install the CLI with `npm install -g litra`, then run `dirname $(which litra-on)`."
+      "description": "The path to the directory where the executable files from the `litra` npm package are installed. Install the CLI with `npm install -g litra`, then run `dirname $(which litra-on)` in your shell to find the correct path."
     },
     {
       "name": "nodeBinaryPath",

--- a/src/manage-devices.tsx
+++ b/src/manage-devices.tsx
@@ -1,6 +1,6 @@
 import { ActionPanel, Action, Icon, List, showToast, Toast } from "@raycast/api";
 import React, { useEffect, useState } from "react";
-import { getCliDirectory } from "./preferences";
+import { getCliDirectory, getNodeBinaryPath } from "./preferences";
 import { getDevices, toggle, isOn, setTemperatureInKelvin, setBrightnessPercentage, checkLitraVersion } from "./utils";
 import { getEnabledTemperaturePresets } from "./temperature-presets";
 import { getEnabledBrightnessPresets } from "./brightness-presets";
@@ -16,12 +16,13 @@ export default function Command() {
   const [enabledBrightnessPresets, setEnabledBrightnessPresets] = useState<Set<number>>(new Set());
 
   const cliDirectory = getCliDirectory();
+  const nodeBinaryPath = getNodeBinaryPath();
 
   useEffect(() => {
     (async () => {
-      await checkLitraVersion(cliDirectory);
+      await checkLitraVersion(cliDirectory, nodeBinaryPath);
 
-      const devices = await getDevices(cliDirectory);
+      const devices = await getDevices(cliDirectory, nodeBinaryPath);
       setDevices(devices);
     })();
   }, []);
@@ -53,8 +54,8 @@ export default function Command() {
                 title="Toggle"
                 icon={Icon.LightBulb}
                 onAction={async () => {
-                  await toggle(cliDirectory, device.serial_number);
-                  const isDeviceOn = await isOn(cliDirectory, device.serial_number);
+                  await toggle(cliDirectory, device.serial_number, nodeBinaryPath);
+                  const isDeviceOn = await isOn(cliDirectory, device.serial_number, nodeBinaryPath);
 
                   if (isDeviceOn) {
                     await showToast({ title: `Turned on ${device.name}`, style: Toast.Style.Success });
@@ -69,7 +70,7 @@ export default function Command() {
                   title={`Set Temperature to ${temperature}K`}
                   icon={Icon.Temperature}
                   onAction={async () => {
-                    await setTemperatureInKelvin(cliDirectory, device.serial_number, temperature);
+                    await setTemperatureInKelvin(cliDirectory, device.serial_number, temperature, nodeBinaryPath);
                     await showToast({
                       title: `Set ${device.name}'s temperature to ${temperature}K`,
                       style: Toast.Style.Success,
@@ -83,7 +84,7 @@ export default function Command() {
                   title={`Set Brightness to ${brightness}%`}
                   icon={Icon.CircleProgress100}
                   onAction={async () => {
-                    await setBrightnessPercentage(cliDirectory, device.serial_number, brightness);
+                    await setBrightnessPercentage(cliDirectory, device.serial_number, brightness, nodeBinaryPath);
                     await showToast({
                       title: `Set ${device.name}'s brightness to ${brightness}%`,
                       style: Toast.Style.Success,

--- a/src/preferences.ts
+++ b/src/preferences.ts
@@ -2,9 +2,15 @@ import { getPreferenceValues } from "@raycast/api";
 
 interface Preferences {
   cliDirectory: string;
+  nodeBinaryPath: string;
 }
 
 export const getCliDirectory = (): string => {
   const { cliDirectory } = getPreferenceValues<Preferences>();
   return cliDirectory;
+};
+
+export const getNodeBinaryPath = (): string => {
+  const { nodeBinaryPath } = getPreferenceValues<Preferences>();
+  return nodeBinaryPath;
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -27,8 +27,6 @@ export const checkLitraVersion = async (cliDirectory: string): Promise<void> => 
 };
 
 const getLitraVersion = async (cliDirectory: string): Promise<string> => {
-  const binPath = path.join(cliDirectory, "litra-devices");
-
   try {
     const { stdout: version } = await runLitraCommand(cliDirectory, "litra-devices", "--version");
     return version.trim();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -14,8 +14,8 @@ interface Device {
 
 const MINIMUM_SUPPORTED_LITRA_VERSION = "4.4.0";
 
-export const checkLitraVersion = async (cliDirectory: string): Promise<void> => {
-  const version = await getLitraVersion(cliDirectory);
+export const checkLitraVersion = async (cliDirectory: string, nodeBinaryPath?: string): Promise<void> => {
+  const version = await getLitraVersion(cliDirectory, nodeBinaryPath);
 
   if (gte(version, MINIMUM_SUPPORTED_LITRA_VERSION)) {
     if (parse(version)?.major != parse(MINIMUM_SUPPORTED_LITRA_VERSION)?.major) {
@@ -26,9 +26,9 @@ export const checkLitraVersion = async (cliDirectory: string): Promise<void> => 
   }
 };
 
-const getLitraVersion = async (cliDirectory: string): Promise<string> => {
+const getLitraVersion = async (cliDirectory: string, nodeBinaryPath?: string): Promise<string> => {
   try {
-    const { stdout: version } = await runLitraCommand(cliDirectory, "litra-devices", "--version");
+    const { stdout: version } = await runLitraCommand(cliDirectory, "litra-devices", "--version", nodeBinaryPath);
     return version.trim();
   } catch (error: any) {
     if (error.stderr.includes("unknown option")) {
@@ -42,7 +42,8 @@ const getLitraVersion = async (cliDirectory: string): Promise<string> => {
 const runLitraCommand = (
   directory: string,
   filename: string,
-  args?: string
+  args?: string,
+  nodeBinaryPath?: string
 ): Promise<{
   stdout: string;
   stderr: string;
@@ -50,39 +51,52 @@ const runLitraCommand = (
   const binPath = path.join(directory, filename);
 
   if (fs.existsSync(binPath)) {
-    return exec(`${binPath} ${args}`);
+    const command = [nodeBinaryPath, binPath, args].filter((argument) => argument).join(" ");
+    return exec(command);
   } else {
     throw `The CLI utility \`${filename}\` is not available in \`${directory}\`. Please check the extension's preferences.`;
   }
 };
 
-export const getDevices = async (cliDirectory: string): Promise<Device[]> => {
-  const { stdout } = await runLitraCommand(cliDirectory, "litra-devices", "--json");
+export const getDevices = async (cliDirectory: string, nodeBinaryPath?: string): Promise<Device[]> => {
+  const { stdout } = await runLitraCommand(cliDirectory, "litra-devices", "--json", nodeBinaryPath);
   return JSON.parse(stdout) as Device[];
 };
 
-export const isOn = async (cliDirectory: string, serialNumber: string): Promise<boolean> => {
-  const devices = await getDevices(cliDirectory);
+export const isOn = async (cliDirectory: string, serialNumber: string, nodeBinaryPath?: string): Promise<boolean> => {
+  const devices = await getDevices(cliDirectory, nodeBinaryPath);
   const device = devices.find((device) => device.serial_number === serialNumber) as Device;
   return device.is_on;
 };
 
-export const toggle = async (cliDirectory: string, serialNumber: string): Promise<void> => {
-  await runLitraCommand(cliDirectory, "litra-toggle", `--serial-number ${serialNumber}`);
+export const toggle = async (cliDirectory: string, serialNumber: string, nodeBinaryPath?: string): Promise<void> => {
+  await runLitraCommand(cliDirectory, "litra-toggle", `--serial-number ${serialNumber}`, nodeBinaryPath);
 };
 
 export const setTemperatureInKelvin = async (
   cliDirectory: string,
   serialNumber: string,
-  temperatureInKelvin: number
+  temperatureInKelvin: number,
+  nodeBinaryPath?: string
 ): Promise<void> => {
-  await runLitraCommand(cliDirectory, "litra-temperature-k", `${temperatureInKelvin} --serial-number ${serialNumber}`);
+  await runLitraCommand(
+    cliDirectory,
+    "litra-temperature-k",
+    `${temperatureInKelvin} --serial-number ${serialNumber}`,
+    nodeBinaryPath
+  );
 };
 
 export const setBrightnessPercentage = async (
   cliDirectory: string,
   serialNumber: string,
-  brightnessPercentage: number
+  brightnessPercentage: number,
+  nodeBinaryPath?: string
 ): Promise<void> => {
-  await runLitraCommand(cliDirectory, "litra-brightness", `${brightnessPercentage} --serial-number ${serialNumber}`);
+  await runLitraCommand(
+    cliDirectory,
+    "litra-brightness",
+    `${brightnessPercentage} --serial-number ${serialNumber}`,
+    nodeBinaryPath
+  );
 };


### PR DESCRIPTION
This PR fixes support for non-standard Node.js installations (e.g. from `nvm`) where we get a `env: node: No such file or directory` error when trying to run `/usr/bin/env node`.

It adds a new optional "Node.js binary path" setting which can be set to point directly to the Node.js binary, rather than relying on `/usr/bin/env node`.

Fixes https://github.com/raycast/extensions/issues/5476.