### PR TITLE
Target devices based on their device path, not their serial number

### DIFF
--- a/src/manage-devices.tsx
+++ b/src/manage-devices.tsx
@@ -46,19 +46,19 @@ export default function Command() {
       {devices.length
         ? devices.map((device) => (
             <List.Item
-              key={device.serial_number}
+              key={device.device_path}
               title={device.device_type}
               subtitle={`${device.is_on ? "💡" : "💡🚫"} ${device.brightness_in_lumen} lm / ${
                 device.temperature_in_kelvin
-              } K (${device.serial_number})`}
+              } K (${device.serial_number || device.device_path})`}
               actions={
                 <ActionPanel>
                   <Action
                     title="Toggle"
                     icon={Icon.LightBulb}
                     onAction={async () => {
-                      await toggle(device.serial_number, litraBinaryPath);
-                      const isDeviceOn = await isOn(device.serial_number, litraBinaryPath);
+                      await toggle(device.device_path, litraBinaryPath);
+                      const isDeviceOn = await isOn(device.device_path, litraBinaryPath);
 
                       if (isDeviceOn) {
                         await showToast({ title: `Turned on ${device.device_type}`, style: Toast.Style.Success });
@@ -75,7 +75,7 @@ export default function Command() {
                       title={`Set Temperature to ${temperature}K`}
                       icon={Icon.Temperature}
                       onAction={async () => {
-                        await setTemperatureInKelvin(device.serial_number, temperature, litraBinaryPath);
+                        await setTemperatureInKelvin(device.device_path, temperature, litraBinaryPath);
                         await showToast({
                           title: `Set ${device.device_type}'s temperature to ${temperature}K`,
                           style: Toast.Style.Success,
@@ -91,7 +91,7 @@ export default function Command() {
                       title={`Set Brightness to ${brightness}%`}
                       icon={Icon.CircleProgress100}
                       onAction={async () => {
-                        await setBrightnessPercentage(device.serial_number, brightness, litraBinaryPath);
+                        await setBrightnessPercentage(device.device_path, brightness, litraBinaryPath);
                         await showToast({
                           title: `Set ${device.device_type}'s brightness to ${brightness}%`,
                           style: Toast.Style.Success,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 export interface Device {
   device_type: string;
   serial_number: string;
+  device_path: string;
   is_on: boolean;
   brightness_in_lumen: number;
   temperature_in_kelvin: number;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -16,8 +16,8 @@ const joinWordsWithCommasThenOr = (words: string[]): string => {
   }
 };
 
-const MINIMUM_SUPPORTED_LITRA_VERSION = "0.2.0";
-const SUPPORTED_MAJOR_LITRA_VERSIONS = [0, 1];
+const MINIMUM_SUPPORTED_LITRA_VERSION = "2.4.0";
+const SUPPORTED_MAJOR_LITRA_VERSIONS = [2];
 const ALLOWED_MAJOR_VERSIONS_STRING = joinWordsWithCommasThenOr(
   SUPPORTED_MAJOR_LITRA_VERSIONS.map((majorVersion) => `v${majorVersion}.x`),
 );
@@ -67,32 +67,28 @@ export const getDevices = async (binaryPath: string): Promise<Device[]> => {
   return JSON.parse(stdout) as Device[];
 };
 
-export const isOn = async (serialNumber: string, binaryPath: string): Promise<boolean> => {
+export const isOn = async (devicePath: string, binaryPath: string): Promise<boolean> => {
   const devices = await getDevices(binaryPath);
-  const device = devices.find((device) => device.serial_number === serialNumber) as Device;
+  const device = devices.find((device) => device.device_path === devicePath) as Device;
   return device.is_on;
 };
 
-export const toggle = async (serialNumber: string, binaryPath: string): Promise<void> => {
-  await runLitraCommand(binaryPath, "toggle", `--serial-number ${serialNumber}`);
+export const toggle = async (devicePath: string, binaryPath: string): Promise<void> => {
+  await runLitraCommand(binaryPath, "toggle", `--device-path ${devicePath}`);
 };
 
 export const setTemperatureInKelvin = async (
-  serialNumber: string,
+  devicePath: string,
   temperatureInKelvin: number,
   binaryPath: string,
 ): Promise<void> => {
-  await runLitraCommand(binaryPath, "temperature", `--value ${temperatureInKelvin} --serial-number ${serialNumber}`);
+  await runLitraCommand(binaryPath, "temperature", `--value ${temperatureInKelvin} --device-path ${devicePath}`);
 };
 
 export const setBrightnessPercentage = async (
-  serialNumber: string,
+  devicePath: string,
   brightnessPercentage: number,
   binaryPath: string,
 ): Promise<void> => {
-  await runLitraCommand(
-    binaryPath,
-    "brightness",
-    `--percentage ${brightnessPercentage} --serial-number ${serialNumber}`,
-  );
+  await runLitraCommand(binaryPath, "brightness", `--percentage ${brightnessPercentage} --device-path ${devicePath}`);
 };


### PR DESCRIPTION
This switches to using the device path rather than the serial number to target Litra devices, addressing a known issue (see https://github.com/raycast/extensions/issues/20332) where some Litra devices don't include a serial number causing the extension to fail.

This change means boosting the required `litra` CLI version for the extension from v0.2.0 to the brand new v2.4.0, which adds device path support.

Fixes https://github.com/raycast/extensions/issues/20332.